### PR TITLE
Move `dotenv` to development dependency

### DIFF
--- a/cloverrb.gemspec
+++ b/cloverrb.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"
+  spec.add_development_dependency "dotenv"
 
   spec.add_dependency "httparty"
-  spec.add_dependency "dotenv"
   spec.add_dependency "activesupport"
 end


### PR DESCRIPTION
This library is causing dotenv to be loaded in production. This is not always desired.